### PR TITLE
FIX: Disable alarm color in combo box

### DIFF
--- a/skywalker/gui.py
+++ b/skywalker/gui.py
@@ -283,6 +283,11 @@ class SkywalkerGui(Display):
         close_dict = dict(RE=self.RE, console=console)
         self.destroyed.connect(partial(SkywalkerGui.on_close, close_dict))
 
+        # TODO remove this once PyDMEnumComboBox supports alarm borders
+        # For now, disable alarms on PyDMEnumComboBox
+        ui.image_state_select.alarm_style_sheet_map = {n: '{}' for n in
+                                                       range(5)}
+
         # Put out the initialization message.
         init_base = 'Skywalker GUI initialized in '
         if self.sim:


### PR DESCRIPTION
PyDM will support border alarm colors on all the widgets after https://github.com/slaclab/pydm/pull/81
Until then, disable the alarm colors on the combo box so my eyes stop burning.