### PR TITLE
Start with no procedure selected

### DIFF
--- a/skywalker/gui.ui
+++ b/skywalker/gui.ui
@@ -972,7 +972,7 @@
                     <property name="alignment">
                      <set>Qt::AlignCenter</set>
                     </property>
-                    <property name="precision">
+                    <property name="precision" stdset="0">
                      <number>3</number>
                     </property>
                    </widget>
@@ -1006,7 +1006,7 @@
                     <property name="alignment">
                      <set>Qt::AlignCenter</set>
                     </property>
-                    <property name="precision">
+                    <property name="precision" stdset="0">
                      <number>3</number>
                     </property>
                    </widget>
@@ -1395,14 +1395,14 @@
                     <property name="whatsThis">
                      <string/>
                     </property>
-                    <property name="userDefinedPrecision" stdset="0">
-                     <bool>true</bool>
+                    <property name="precision" stdset="0">
+                     <number>3</number>
                     </property>
                     <property name="showUnits" stdset="0">
                      <bool>true</bool>
                     </property>
-                    <property name="precision">
-                     <number>3</number>
+                    <property name="userDefinedPrecision" stdset="0">
+                     <bool>true</bool>
                     </property>
                    </widget>
                   </item>
@@ -1432,14 +1432,14 @@
                     <property name="whatsThis">
                      <string/>
                     </property>
-                    <property name="userDefinedPrecision" stdset="0">
-                     <bool>true</bool>
+                    <property name="precision" stdset="0">
+                     <number>3</number>
                     </property>
                     <property name="showUnits" stdset="0">
                      <bool>true</bool>
                     </property>
-                    <property name="precision">
-                     <number>3</number>
+                    <property name="userDefinedPrecision" stdset="0">
+                     <bool>true</bool>
                     </property>
                    </widget>
                   </item>
@@ -1501,14 +1501,14 @@
                     <property name="whatsThis">
                      <string/>
                     </property>
-                    <property name="userDefinedPrecision" stdset="0">
-                     <bool>true</bool>
+                    <property name="precision" stdset="0">
+                     <number>3</number>
                     </property>
                     <property name="showUnits" stdset="0">
                      <bool>true</bool>
                     </property>
-                    <property name="precision">
-                     <number>3</number>
+                    <property name="userDefinedPrecision" stdset="0">
+                     <bool>true</bool>
                     </property>
                    </widget>
                   </item>
@@ -1626,14 +1626,14 @@
                     <property name="whatsThis">
                      <string/>
                     </property>
-                    <property name="userDefinedPrecision" stdset="0">
-                     <bool>true</bool>
+                    <property name="precision" stdset="0">
+                     <number>3</number>
                     </property>
                     <property name="showUnits" stdset="0">
                      <bool>true</bool>
                     </property>
-                    <property name="precision">
-                     <number>3</number>
+                    <property name="userDefinedPrecision" stdset="0">
+                     <bool>true</bool>
                     </property>
                    </widget>
                   </item>
@@ -2366,6 +2366,16 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEnumComboBox</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.enum_combo_box</header>
+  </customwidget>
+  <customwidget>
    <class>PyDMImageView</class>
    <extends>QWidget</extends>
    <header>pydm.widgets.image</header>
@@ -2379,16 +2389,6 @@
    <class>PyDMLineEdit</class>
    <extends>QLineEdit</extends>
    <header>pydm.widgets.line_edit</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMEnumComboBox</class>
-   <extends>QWidget</extends>
-   <header>pydm.widgets.enum_combo_box</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMByteIndicator</class>
-   <extends>QWidget</extends>
-   <header>pydm.widgets.byte</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/skywalker/widgetgroup.py
+++ b/skywalker/widgetgroup.py
@@ -339,8 +339,6 @@ class ImgObjWidget(ObjWidgetGroup):
                       padding=0.0)
         view.setLimits(xMin=0, xMax=self.raw_size_x,
                        yMin=0, yMax=self.raw_size_y)
-        img_widget.resetImageChannel()
-        img_widget.resetWidthChannel()
         img_widget.setMinimumWidth(self.size_x)
         img_widget.setMinimumHeight(self.size_y)
         if width_pv is None:
@@ -351,8 +349,8 @@ class ImgObjWidget(ObjWidgetGroup):
             image_channel = ''
         else:
             image_channel = self.protocol + image_pv
-        img_widget.setWidthChannel(width_channel)
-        img_widget.setImageChannel(image_channel)
+        img_widget.widthChannel = width_channel
+        img_widget.imageChannel = image_channel
         self.cent_x.subscribe(self.update_centroid)
         self.cent_y.subscribe(self.update_centroid)
 


### PR DESCRIPTION
This prevents an accidental alignment.
Incidentally, fixed a bug in setting initialization when none are saved/loaded.

Requires #28 
Closes #16