### PR TITLE
ENH: Title for settings dialog

### DIFF
--- a/skywalker/settings.py
+++ b/skywalker/settings.py
@@ -141,6 +141,7 @@ class SettingsGroup:
         """
         self.settings = {}
         self.window = QDialog(parent=parent)
+        self.window.setWindowTitle('Skywalker Settings')
         main_layout = QVBoxLayout()
         self.window.setLayout(main_layout)
         self.window.setSizePolicy(QSizePolicy.Minimum,


### PR DESCRIPTION
Fixes an issue where junk characters from the command-line options sometimes end up in the title spot.