### PR TITLE
FIX: MFX Segfault

### DIFF
--- a/skywalker/logger.py
+++ b/skywalker/logger.py
@@ -18,9 +18,11 @@ class GuiHandler(logging.Handler):
     def emit(self, record):
         if self.text_widget is not None:
             try:
-                msg = self.format(record)
-                cursor = self.text_widget.cursorForPosition(QPoint(0, 0))
-                cursor.insertText(msg + self.terminator)
+                all_msg = self.format(record)
+                split_msg = all_msg.split(self.terminator)
+                for msg in reversed(split_msg):
+                    cursor = self.text_widget.cursorForPosition(QPoint(0, 0))
+                    cursor.insertText(msg + self.terminator)
             except Exception:
                 self.handleError(record)
 


### PR DESCRIPTION
QT was segfaulting about 3-5 seconds after logging a long traceback to the GUI logger. Sending each line one at a time seems to make it happy. This was only affecting MFX, but we couldn't identify why. Others have experienced similar segfaults with qt according to stack overflow.