### PR TITLE
FIX: Make settings window appear on button always

### DIFF
--- a/skywalker/gui.py
+++ b/skywalker/gui.py
@@ -639,7 +639,7 @@ class SkywalkerGui(Display):
     @pyqtSlot()
     def on_settings_button(self):
         try:
-            pos = self.settings_button.mapToGlobal(self.settings_button.pos())
+            pos = self.ui.mapToGlobal(self.settings_button.pos())
             dialog_return = self.settings.dialog_at(pos)
             if dialog_return == QDialog.Accepted:
                 self.cache_settings()


### PR DESCRIPTION
This ended up being a one-line change to make the window position be (window pos + settings pos) instead of (window pos + settings pos + settings pos). Doing (settings pos) by itself didn't work because this ended up being a fixed point on the screen based on the original location of the settings button.