### PR TITLE
FIX: Logging Issues

### DIFF
--- a/skywalker/gui.py
+++ b/skywalker/gui.py
@@ -752,8 +752,7 @@ class SkywalkerGui(Display):
                 if chosen_imager is not None:
                     name = chosen_imager.name
                     if name != combo.currentText():
-                        # TODO why does this segfault
-                        # logger.info('Automatically switching cam to %s',name)
+                        logger.info('Automatically switching cam to %s',name)
                         index = self.all_imager_names.index(name)
                         combo.setCurrentIndex(index)
 

--- a/skywalker/logger.py
+++ b/skywalker/logger.py
@@ -1,30 +1,53 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import threading
 import logging
 
-from pydm.PyQt.QtCore import QPoint
+from pydm.PyQt.QtCore import QPoint, pyqtSlot, pyqtSignal
 
 
 class GuiHandler(logging.Handler):
     """
     Logging handler that logs to a scrolling text widget.
     """
-    terminator = '\n'
-
     def __init__(self, text_widget, level=logging.NOTSET):
         super().__init__(level=level)
-        self.text_widget = text_widget
+        self.log_writer = LogWriter(text_widget)
+        self.log_signal = pyqtSignal(str)
+        self.log_signal.connect(self.log_writer.write_log)
+        self.lock = threading.RLock()
 
     def emit(self, record):
-        if self.text_widget is not None:
-            try:
+        with self.lock:
+            if self.log_writer is not None:
                 all_msg = self.format(record)
-                split_msg = all_msg.split(self.terminator)
-                for msg in reversed(split_msg):
-                    cursor = self.text_widget.cursorForPosition(QPoint(0, 0))
-                    cursor.insertText(msg + self.terminator)
-            except Exception:
-                self.handleError(record)
+                self.log_signal.emit(all_msg)
 
     def close(self):
+        with self.lock:
+            self.log_writer.log_close()
+            self.log_signal.disconnect()
+            self.log_signal = None
+            self.log_writer = None
+
+
+class LogWriter(QObject):
+    """
+    QObject to do the writing
+    """
+    terminator = '\n'
+
+    def __init__(self, text_widget):
+        super().__init__(parent=text_widget)
+        self.text_widget = text_widget
+
+    @pyqtSlot(str)
+    def write_log(self, all_msg):
+        if self.text_widget is not None:
+            split_msg = all_msg.split(self.terminator)
+            for msg in reversed(split_msg):
+                cursor = self.text_widget.cursorForPosition(QPoint(0, 0))
+                cursor.insertText(msg + self.terminator)
+
+    def log_close(self):
         self.text_widget = None


### PR DESCRIPTION
Logging was failing before in background threads because all GUI operations MUST be done by the GUI thread. This implementation looks very roundabout, but this is the pattern I needed to get the log widget to work correctly.

This task requires both a logging handler object to catch the log requests and a `QObject` to execute the GUI operations. Yes, the `QObject` sends a signal to itself, but this is because a `pyqtSignal` needs to be attached to a `QObject`, and the logging handler cannot be a `QObject`.

This ensures that the slot's execution ends up on the Qt event loop and gets executed in the main thread. It also lets us keep all information about how the logging works in this file instead of tacking it onto `gui.py`, which already needs to be cut down a bit.