### PR TITLE
FIX: Image Nitpicking

### DIFF
--- a/skywalker/gui.ui
+++ b/skywalker/gui.ui
@@ -51,8 +51,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1109</width>
-        <height>1002</height>
+        <width>1111</width>
+        <height>1004</height>
        </rect>
       </property>
       <property name="styleSheet">
@@ -219,6 +219,9 @@
               </property>
               <property name="whatsThis">
                <string/>
+              </property>
+              <property name="maxRedrawRate" stdset="0">
+               <number>5</number>
               </property>
              </widget>
             </item>

--- a/skywalker/widgetgroup.py
+++ b/skywalker/widgetgroup.py
@@ -143,7 +143,7 @@ class ValueWidgetGroup(BaseWidgetGroup):
         else:
             try:
                 return self.force_type(raw)
-            except:
+            except Exception:
                 return None
 
     @value.setter
@@ -195,7 +195,7 @@ class PydmWidgetGroup(BaseWidgetGroup):
                 chan = self.protocol + pvname
             try:
                 widget.setChannel(chan)
-            except:
+            except Exception:
                 widget.channel = chan
 
     def change_pvs(self, pvnames, name=None, **kwargs):
@@ -356,17 +356,13 @@ class ImgObjWidget(ObjWidgetGroup):
             width_pv = pvnames[0]
             image_pv = pvnames[1]
             image_item = img_widget.getImageItem()
-            image_item.setTransformOriginPoint(self.raw_size_x//2,
-                                               self.raw_size_y//2)
-            image_item.setRotation(rotation)
+            image_item.setTransformOriginPoint(self.size_x/2,
+                                               self.size_y/2)
+            image_item.setRotation((rotation + 90) % 360)
             view = img_widget.getView()
-            view.setRange(xRange=(0, self.raw_size_x),
-                          yRange=(0, self.raw_size_y),
+            view.setRange(xRange=(0, self.size_x),
+                          yRange=(0, self.size_y),
                           padding=0.0)
-            view.setLimits(xMin=0, xMax=self.raw_size_x,
-                           yMin=0, yMax=self.raw_size_y)
-            img_widget.setMinimumWidth(self.size_x)
-            img_widget.setMinimumHeight(self.size_y)
 
         if width_pv is None:
             width_channel = ''


### PR DESCRIPTION
- Set max rate to 5Hz
- Add 90 to rotation because the origin angle changed (not sure how)
- Size the image more correctly, the image below is the default size/location before manual panning. There is still empty space where the widget expands vertically. Please excuse my lack of dark theme.

![screenshot-skywalker](https://user-images.githubusercontent.com/10647860/33341196-0fc32760-d433-11e7-9722-e28373a41ed0.png)
