### PR TITLE
ENH: Make preserve connections more robust and extend to be default

### DIFF
--- a/skywalker/widgetgroup.py
+++ b/skywalker/widgetgroup.py
@@ -232,11 +232,13 @@ class PydmWidgetGroup(BaseWidgetGroup):
         protocol = self.protocol.split('://')[0]
         plugin = QApp.plugins[protocol]
         for widget in self._preserve:
-            for channel in widget.channels():
-                address = plugin.get_address(channel)
-                connection = plugin.connections[address]
-                if connection.listener_count < 2:
-                    connection.listener_count += 1
+            if hasattr(widget, 'channels'):
+                for channel in widget.channels():
+                    address = plugin.get_address(channel)
+                    if address:
+                        connection = plugin.connections[address]
+                        if connection.listener_count < 2:
+                            connection.listener_count += 1
 
 
 class ObjWidgetGroup(PydmWidgetGroup):
@@ -263,6 +265,8 @@ class ObjWidgetGroup(PydmWidgetGroup):
             name = None
         else:
             name = obj.name
+        if preserve is None:
+            preserve = widgets
         pvnames = self.get_pvnames(obj)
         super().__init__(widgets, pvnames, label=label, name=name,
                          preserve=preserve, **kwargs)


### PR DESCRIPTION
We're blocking some pydm connections from cleaning themselves up to avoid destroying the pyepics cache when our ophyd objects also rely on it. This PR makes preserve the default option when the pvs are seeded from an ophyd object and fixes some edge cases that I found in the process.