### PR TITLE
FIX: Typo in happi version spec

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
 
     run:
       - python {{PY_VER}}*,>=3
-      - happi=0.5.0
+      - happi <=0.5.0
       - pcds-devices
       - lightpath
       - psbeam


### PR DESCRIPTION
## Description
Fixes typo in conda-recipe that causes failure when building

## Tests
Tested locally