### PR TITLE
BLD: pin our dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage hypothesis=3.11.6 pip wheel swig pyqt=5 pytest happi=0.5.0 pcds-devices lightpath psbeam pswalker  -c lightsource2-tag -c skywalker-tag -c conda-forge  -c pydm-dev -c gsecars
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage hypothesis=3.11.6 pip wheel swig pyqt=5 pytest happi=0.5.0 pcds-devices=0.2.0 lightpath=0.2.1 psbeam=0.0.3 pswalker=0.2.0  -c lightsource2-tag -c skywalker-tag -c conda-forge  -c pydm-dev -c gsecars
   #Launch Conda environment
   - source activate test-environment
   #Install requirements

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,10 +15,10 @@ requirements:
     run:
       - python {{PY_VER}}*,>=3
       - happi <=0.5.0
-      - pcds-devices
-      - lightpath
-      - psbeam
-      - pswalker
+      - pcds-devices ==0.2.0
+      - lightpath ==0.2.1
+      - psbeam ==0.0.3
+      - pswalker ==0.2.0
       - pyqt >=5
       - numpy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-git+https://github.com/slaclab/lightpath#egg=lightpath
+git+https://github.com/slaclab/lightpath@v0.2.1
 git+https://github.com/slaclab/happi@v0.5.0
-git+https://github.com/slaclab/pcds-devices#egg=pcds-devices
-git+https://github.com/slaclab/psbeam#egg=psbeam
-git+https://github.com/slaclab/pswalker#egg=pswalker
+git+https://github.com/slaclab/pcds-devices@v0.2.0
+git+https://github.com/slaclab/psbeam@v0.0.3
+git+https://github.com/slaclab/pswalker@v0.2.0
 git+https://github.com/slaclab/pydm
 git+https://github.com/lcls-pcds/QDarkStyleSheet
 simplejson


### PR DESCRIPTION
We're finally stable enough to do this at the skywalker level.

This build will fail until I tag the 0.2.0 pswalker release.