### PR TITLE
BLD: up pswalker and lightpath versions, use ranges instead of hard pins

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,10 +15,10 @@ requirements:
     run:
       - python {{PY_VER}}*,>=3
       - happi <=0.5.0
-      - pcds-devices ==0.2.0
-      - lightpath ==0.2.1
-      - psbeam ==0.0.3
-      - pswalker ==0.2.0
+      - pcds-devices >=0.2.0,<0.3
+      - lightpath >=0.2.2,<0.3
+      - psbeam >=0.0.3,<0.1
+      - pswalker >=0.2.1,<0.3
       - pyqt >=5
       - numpy
 


### PR DESCRIPTION
If we're doing our jobs right, the bugfix releases of dependencies shouldn't harm the higher-level packages. We should allow them in the meta.yaml file so I can make environments with skywalker that accept the bugfix releases.